### PR TITLE
Fixed version restore behaviour when executing 'poetry run' commands on Linux with poetry >= 1.0.0b2

### DIFF
--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -46,6 +46,13 @@ function test_keep_pyproject_modifications {
     cat $dummy/pyproject.toml | grep $package
 }
 
+function test_poetry_run {
+    $do_poetry run echo "Testing 'poetry run'"
+    # Make sure original version number is restored
+    # also when executing a 'poetry run' command
+    cat $dummy/pyproject.toml | grep "version = \"0.0.999\""
+}
+
 function run_test {
     cd $dummy
     git checkout -- $dummy


### PR DESCRIPTION
Hello,
as of version 1.0.0b2, on Linux, the `poetry run` command uses `os.execvp` function instead of spawning a new subprocess.

For poetry-dynamic-versioning this change has the side-effect that the `atexit` hook is no longer called and, as a consequence, the original version string in `pyproject.toml` is not properly restored.

The proposed solution is to also patch `poetry.console.command.run.RunCommand.handle` function in order to immediately call `deactivate` before executing the desired command/script.