### PR TITLE
Fixed issues when trying to configure the file paths to match with toml.

### DIFF
--- a/poetry_dynamic_versioning/__init__.py
+++ b/poetry_dynamic_versioning/__init__.py
@@ -157,7 +157,8 @@ def _substitute_version(
 
     files = set()  # type: MutableSet[Path]
     for file_glob in file_globs:
-        for match in root.glob(file_glob):
+        # since file_glob here could be a non-internable string
+        for match in root.glob(str(file_glob)):
             files.add(match.resolve())
     for file in files:
         original_content = file.read_text()


### PR DESCRIPTION
Since Path.glob eventually interns the strings and file_glob here could be a `<tomlkit.items.String>` instead of `<str>` we need to just ensure that we pass a plain vanilla string to glob.