### PR TITLE
Add `style` to the format-jinja vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ In your pyproject.toml file, you may configure the following options:
     * `dirty` (boolean)
     * `tagged_metadata` (string or None)
     * `version` (dunumai.Version)
+    * `style` (dunumai.Style or None)
     * `env` (dictionary of environment variables)
 
     Available functions:

--- a/poetry_dynamic_versioning/__init__.py
+++ b/poetry_dynamic_versioning/__init__.py
@@ -164,6 +164,7 @@ def _get_version(config: Mapping) -> Tuple[Version, str]:
         default_context = {
             "base": base,
             "version": version,
+            "style": style,
             "stage": version.stage,
             "revision": revision,
             "distance": version.distance,


### PR DESCRIPTION
This is needed since some of the methods on the version object expect a Style instance not a string.

Alternatively we could just change dunamai to do something like

```
    if style is not None and if isinstance(style, str):
        style = Style(style)
```