### PR TITLE
Change subdirectory glob to check all dunder files

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ In your pyproject.toml file, you may configure the following options:
   into additional files other than just pyproject.toml. These changes will be
   reverted when the plugin deactivates.
   * `files`: List of globs for any files that need substitutions. Default:
-    `["*.py", "*/__init__.py", "*/__version__.py", "*/_version.py"]`.
+    `["*.py", "*/__*__.py", "*/_version.py"]`.
     To disable substitution, set this to an empty list.
   * `patterns`: List of regular expressions for the text to replace.
     Each regular expression must have two capture groups, which are any

--- a/poetry_dynamic_versioning/__init__.py
+++ b/poetry_dynamic_versioning/__init__.py
@@ -84,7 +84,7 @@ def _default_config() -> Mapping:
                 "latest-tag": False,
                 "subversion": {"tag-dir": "tags"},
                 "substitution": {
-                    "files": ["*.py", "*/__init__.py", "*/__version__.py", "*/_version.py"],
+                    "files": ["*.py", "*/__*__.py", "*/_version.py"],
                     "patterns": [r"(^__version__\s*=\s*['\"])[^'\"]*(['\"])"],
                 },
                 "style": None,


### PR DESCRIPTION
Using */__*__.py allows freedom to use __version__.py, __about__.py,
__init__.py, etc.