### PR TITLE
Quote brackets in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ that relied on a `*.pth` import hack, but this is no longer supported,
 so you should migrate to the standardized plugin and Poetry 1.2.0+.
 
 ## Installation
-* Run: `poetry self add poetry-dynamic-versioning[plugin]`
+* Run: `poetry self add "poetry-dynamic-versioning[plugin]"`
 * Add this section to your pyproject.toml:
   ```toml
   [tool.poetry-dynamic-versioning]


### PR DESCRIPTION
Running `poetry self add poetry-dynamic-versioning[plugin]` results in 
`zsh: no matches found: poetry-dynamic-versioning[plugin]`. Quotes should help.