### PR TITLE
fix: failing test due to hardcoded string in test

### DIFF
--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -124,7 +124,7 @@ def test__enable_in_doc__empty():
                 enable = true
 
                 [build-system]
-                requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+                requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
                 build-backend = "poetry_dynamic_versioning.backend"
             """
         ).lstrip()


### PR DESCRIPTION
A test (test__enable_in_doc__empty()) fails due to hardcoded strings in `tests/test_unit.py` becoming out of sync with changes in `pyproject.toml`.

Full output of failing test:

```
=================================== FAILURES ===================================
__________________________ test__enable_in_doc__empty __________________________

    def test__enable_in_doc__empty():
        doc = tomlkit.parse("")
        updated = cli._enable_in_doc(doc)
        assert updated[cli.Key.tool][cli.Key.pdv][cli.Key.enable] is True
        assert updated[cli.Key.build_system][cli.Key.requires] == cli._DEFAULT_REQUIRES
        assert updated[cli.Key.build_system][cli.Key.build_backend] == cli._DEFAULT_BUILD_BACKEND
>       assert (
            tomlkit.dumps(updated)
            == textwrap.dedent(
                """
                    [tool.poetry-dynamic-versioning]
                    enable = true

                    [build-system]
                    requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
                    build-backend = "poetry_dynamic_versioning.backend"
                """
            ).lstrip()
        )
E       assert '[tool.poetry...ng.backend"\n' == '[tool.poetry...ng.backend"\n'
E           [tool.poetry-dynamic-versioning]
E           enable = true
E
E           [build-system]
E         - requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
E         + requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
E         ?                                                             ++++++++++++++
E           build-backend = "poetry_dynamic_versioning.backend"

tests/test_unit.py:119: AssertionError
=========================== short test summary info ============================
FAILED tests/test_unit.py::test__enable_in_doc__empty - assert '[tool.poetry....
========================= 1 failed, 20 passed in 0.27s =========================
```