### PR TITLE
Add pipx to the plugin installation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ be sure to uninstall it before proceeding.
 Install the poetry plugin (Pick one of the options below):
 1. `poetry self add "poetry-dynamic-versioning[plugin]"`
 2. `pipx inject poetry poetry-dynamic-versioning[plugin]` - Use if you installed poetry with pipx
-3. See the [poetry plugin documentation](https://python-poetry.org/docs/master/plugins/#using-plugins) for up to date documentation.
+3. See the [poetry plugin documentation](https://python-poetry.org/docs/master/plugins/#using-plugins) for up to date documentation
 
 After poetry plugin installation:
 * Run in your project: `poetry dynamic-versioning enable`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ so you should migrate to the standardized plugin and Poetry 1.2.0+.
 If you've previously installed the deprecated `poetry-dynamic-versioning-plugin` package,
 be sure to uninstall it before proceeding.
 
-* Run: `poetry self add "poetry-dynamic-versioning[plugin]"`
+Install the poetry plugin (Pick one of the options below):
+1. `poetry self add "poetry-dynamic-versioning[plugin]"`
+2. `pipx inject poetry poetry-dynamic-versioning[plugin]` - Use if you installed poetry with pipx
+3. See the [poetry plugin documentation](https://python-poetry.org/docs/master/plugins/#using-plugins) for up to date documentation.
+
+After poetry plugin installation:
 * Run in your project: `poetry dynamic-versioning enable`
 
   Or you can update your pyproject.toml manually:


### PR DESCRIPTION
Add pipx to the plugin installation options. Open to ideas for how to format this, it seems better like this, but it's not perfect!

I hit `No module named 'poetry.core.semver'` when installing this plugin, and realized I should follow a different plugin installation path for this one, took me a bit to find so I thought I'd take the time to prevent my mistake again and help others!

More information here https://github.com/python-poetry/poetry/issues/8618#issuecomment-1961485761