### PR TITLE
Actually ensure the contents of `pyproject.toml` do not change after cleanup

### DIFF
--- a/poetry_dynamic_versioning/__init__.py
+++ b/poetry_dynamic_versioning/__init__.py
@@ -668,7 +668,7 @@ def _get_and_apply_version(
     elif pep621:
         name = pyproject["project"]["name"]
         original = pyproject["tool"]["poetry"]["version"]
-        dynamic_array = pyproject["project"]["dynamic"].copy()
+        dynamic_array = pyproject["project"]["dynamic"]
     else:
         return None
 

--- a/tests/project-pep621/pyproject.toml
+++ b/tests/project-pep621/pyproject.toml
@@ -1,6 +1,8 @@
 [project]
 name = "project-pep621"
-dynamic = ["version"]
+dynamic = [
+    "version",  # a comment that should be preserved
+]
 
 [tool.poetry]
 # The plugin itself doesn't need this, but Poetry does:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -286,8 +286,13 @@ def test_pep621_with_dynamic_version():
 def test_pep621_with_dynamic_version_and_cleanup():
     version = dunamai.Version.from_git().serialize()
 
+    contents_before = DUMMY_PEP621_PYPROJECT.read_bytes().decode("utf-8")
+
     run("poetry build", where=DUMMY_PEP621)
-    pyproject = tomlkit.parse(DUMMY_PEP621_PYPROJECT.read_bytes().decode("utf-8"))
+    contents_after = DUMMY_PEP621_PYPROJECT.read_bytes().decode("utf-8")
+    assert contents_before == contents_after
+
+    pyproject = tomlkit.parse(contents_after)
     assert "version" not in pyproject["project"]
     assert "version" in pyproject["project"]["dynamic"]
     assert '__version__ = "0.0.0"' in (DUMMY_PEP621 / "project_pep621" / "__init__.py").read_bytes().decode("utf-8")


### PR DESCRIPTION
Now with tests...

Related:

- What https://github.com/mtkennerly/poetry-dynamic-versioning/pull/206 should've been
- Closes https://github.com/mtkennerly/poetry-dynamic-versioning/issues/204