### PR TITLE
Fix cli add "version" into dynamic array even already included

### DIFF
--- a/poetry_dynamic_versioning/cli.py
+++ b/poetry_dynamic_versioning/cli.py
@@ -137,7 +137,7 @@ def _enable_in_doc(doc: tomlkit.TOMLDocument) -> tomlkit.TOMLDocument:
 
         if doc[Key.project].get(Key.dynamic) is None:
             doc[Key.project][Key.dynamic] = [Key.version]
-        else:
+        elif Key.version not in doc[Key.project][Key.dynamic]:
             doc[Key.project][Key.dynamic].append(Key.version)
 
         if doc[Key.tool].get(Key.poetry) is None:


### PR DESCRIPTION
# How to reproduce
- My pyproject.toml
```TOML
[project]
name = "asynctor"
description = ""
authors = []
readme = "README.md"
license = { text = "MIT" }
requires-python = ">=3.9"
dynamic = [ "version" ]
dependencies = []

[tool.poetry]
version = "0.0.1"

[build-system]
requires = ["poetry-core>=2.0"]
build-backend = "poetry.core.masonry.api"
```
- After running `poetry dynamic-versioning enable`, the dynamic array of project section was changed to be:
```
dynamic = [ "version", "version" ]
```