### PR TITLE
Apply patches via the actually used `poetry`

### DIFF
--- a/poetry_dynamic_versioning/plugin.py
+++ b/poetry_dynamic_versioning/plugin.py
@@ -179,7 +179,7 @@ class DynamicVersioningPlugin(ApplicationPlugin):
 
         io = _should_apply_with_io(event.command.name)
 
-        _apply_version_via_plugin(self._application.poetry, io=io)
+        _apply_version_via_plugin(event.command.poetry, io=io)
         _patch_dependency_versions(io)
 
     def _revert_version(self, event: ConsoleCommandEvent, kind: str, dispatcher: EventDispatcher) -> None:


### PR DESCRIPTION
In a `ConsoleCommandEvent` handler, where patches are applied, we sometimes get a different `poetry` project (probably by other plugins) from the one that the plugin is originally invoked. This patch changes the so that the plugin will apply to all the Poetry projects that are being used.