### PR TITLE
Remove extra lines that cause the testsuite to fail in 1.8.2

### DIFF
--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -279,7 +279,6 @@ def test__enable_in_doc__project_with_version():
             [project]
             dynamic = ["version"]
 
-            [tool]
             [tool.poetry-dynamic-versioning]
             enable = true
 
@@ -307,7 +306,6 @@ def test__enable_in_doc__project_with_version_override():
             [project]
             dynamic = ["version"]
 
-            [tool]
             [tool.poetry-dynamic-versioning]
             enable = true
 
@@ -336,7 +334,6 @@ def test__enable_in_doc__project_with_dynamic():
             [project]
             dynamic = ["version", "dependencies"]
 
-            [tool]
             [tool.poetry-dynamic-versioning]
             enable = true
 


### PR DESCRIPTION
While updating the Debian package to 1.8.2, I encountered this testsuite failure:

```
============================= test session starts ==============================
platform linux -- Python 3.13.2, pytest-8.3.5, pluggy-1.5.0
rootdir: /build/reproducible-path/python-poetry-dynamic-versioning-1.8.2/.pybuild/cpython3_3.13/build
configfile: pyproject.toml
collected 26 items

tests/test_unit.py .....................FFF..                            [100%]

=================================== FAILURES ===================================
__________________ test__enable_in_doc__project_with_version ___________________

    def test__enable_in_doc__project_with_version():
        doc = tomlkit.parse(
            textwrap.dedent(
                """
                    [project]
                    version = "1.2.3"
                """
            )
        )
        updated = cli._enable_in_doc(doc)
>       assert tomlkit.dumps(updated) == textwrap.dedent(
            """
                [project]
                dynamic = ["version"]
    
                [tool]
                [tool.poetry-dynamic-versioning]
                enable = true
    
                [tool.poetry]
                version = "0.0.0"
    
                [build-system]
                requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
                build-backend = "poetry_dynamic_versioning.backend"
            """
        )
E       assert '\n[project]\...ng.backend"\n' == '\n[project]\...ng.backend"\n'
E         
E           
E           [project]
E           dynamic = ["version"]
E           
E         - [tool]
E           [tool.poetry-dynamic-versioning]...
E         
E         ...Full output truncated (8 lines hidden), use '-vv' to show

tests/test_unit.py:277: AssertionError
______________ test__enable_in_doc__project_with_version_override ______________

    def test__enable_in_doc__project_with_version_override():
        doc = tomlkit.parse(
            textwrap.dedent(
                """
                    [project]
                """
            )
        )
        updated = cli._enable_in_doc(doc, env={plugin._BYPASS_ENV: "1.2.3"})
>       assert tomlkit.dumps(updated) == textwrap.dedent(
            """
                [project]
                dynamic = ["version"]
    
                [tool]
                [tool.poetry-dynamic-versioning]
                enable = true
    
                [tool.poetry]
                version = "1.2.3"
    
                [build-system]
                requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
                build-backend = "poetry_dynamic_versioning.backend"
            """
        )
E       assert '\n[project]\...ng.backend"\n' == '\n[project]\...ng.backend"\n'
E         
E           
E           [project]
E           dynamic = ["version"]
E           
E         - [tool]
E           [tool.poetry-dynamic-versioning]...
E         
E         ...Full output truncated (8 lines hidden), use '-vv' to show

tests/test_unit.py:305: AssertionError
__________________ test__enable_in_doc__project_with_dynamic ___________________

    def test__enable_in_doc__project_with_dynamic():
        doc = tomlkit.parse(
            textwrap.dedent(
                """
                    [project]
                    dynamic = ["version", "dependencies"]
                """
            )
        )
        updated = cli._enable_in_doc(doc)
>       assert tomlkit.dumps(updated) == textwrap.dedent(
            """
                [project]
                dynamic = ["version", "dependencies"]
    
                [tool]
                [tool.poetry-dynamic-versioning]
                enable = true
    
                [tool.poetry]
                version = "0.0.0"
    
                [build-system]
                requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
                build-backend = "poetry_dynamic_versioning.backend"
            """
        )
E       assert '\n[project]\...ng.backend"\n' == '\n[project]\...ng.backend"\n'
E         
E         Skipping 45 identical leading characters in diff, use -v to show
E           s"]
E           
E         - [tool]
E           [tool.poetry-dynamic-versioning]
E           enable = true...
E         
E         ...Full output truncated (7 lines hidden), use '-vv' to show

tests/test_unit.py:334: AssertionError
=========================== short test summary info ============================
FAILED tests/test_unit.py::test__enable_in_doc__project_with_version - assert...
FAILED tests/test_unit.py::test__enable_in_doc__project_with_version_override
FAILED tests/test_unit.py::test__enable_in_doc__project_with_dynamic - assert...
========================= 3 failed, 23 passed in 0.12s =========================
E: pybuild pybuild:389: test: plugin pyproject failed with: exit code=1: cd /build/reproducible-path/python-poetry-dynamic-versioning-1.8.2/.pybuild/cpython3_3.13/build; python3.13 -m pytest tests/test_unit.py
dh_auto_test: error: pybuild --test --test-pytest -i python{version} -p 3.13 returned exit code 13
make: *** [debian/rules:9: binary] Error 25
dpkg-buildpackage: error: debian/rules binary subprocess returned exit status 2
--------------------------------------------------------------------------------
Build finished at 2025-03-29T19:26:09Z
```

I was able to reproduce this in a venv with packages from pip too. The extra `[tool]` lines looked odd to me and the testsuite passes without them.

I'm guessing it was an oversight?