### PR TITLE
Fix man page generation script

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -111,7 +111,7 @@ def docs(ctx):
         "--version",
         version,
         "--author",
-        '"Matthew T. Kennerly (mtkennerly)"',
+        "Matthew T. Kennerly (mtkennerly)",
         "--url",
         "https://github.com/mtkennerly/poetry-dynamic-versioning",
         "--format",

--- a/tasks.py
+++ b/tasks.py
@@ -105,7 +105,7 @@ def docs(ctx):
         "--function",
         "get_parser",
         "--project-name",
-        "poetry-dynamic-versioning",
+        "poetry-dynamic-versioning - Dynamic versioning plugin for Poetry",
         "--prog",
         "poetry-dynamic-versioning",
         "--version",


### PR DESCRIPTION
The Debian linting tool flagged a few issues with the current man page.

This PR fixes them.